### PR TITLE
Moved solvent to hydro, added transform for solute

### DIFF
--- a/pytrx/hydro.py
+++ b/pytrx/hydro.py
@@ -10,37 +10,81 @@ class HydroProperties:
         #Z
         #xyz
 
+
 def add_solvent(d, keys, hp_obj):
     for key in keys:
         d[key] = hp_obj
 
 
-data = {}
+solvent_data = {}
 
 
 acetonitrile = HydroProperties(density=786,                     # kg/m3
                                molar_mass=41.05e-3,             # kg/mol
                                )
+acetonitrile.Z = np.array(['C', 'C', 'H', 'H', 'H', 'N'])
+acetonitrile.xyz = np.array([[  0.000000,    0.000000,    0.006313],
+                             [  0.000000,    0.000000,    1.462539],
+                             [  1.024583,    0.000000,   -0.370908],
+                             [ -0.512291,   -0.887315,   -0.370908],
+                             [ -0.512291,    0.887315,   -0.370908],
+                             [  0.000000,    0.000000,    2.615205]])
 acetonitrile_keys = ['acetonitrile', 'Acetonitrile', 'acn', 'MeCN', 'ACN', 'CH3CN', 'ch3cn']
-add_solvent(data, acetonitrile_keys, acetonitrile)
-
+add_solvent(solvent_data, acetonitrile_keys, acetonitrile)
 
 
 cyclohexane = HydroProperties(density=779,                     # kg/m3
-                               molar_mass=84.16e-3,             # kg/mol
-                               )
+                              molar_mass=84.16e-3,             # kg/mol
+                              )
+cyclohexane.Z = np.array(['C']*6 + ['H']*12)
+cyclohexane.xyz = np.array([[-0.7613, -0.7573,  0.9857],
+                            [ 0.7614, -0.7575,  0.9855],
+                            [-1.2697,  0.5686,  0.4362],
+                            [ 1.2693, -0.5690, -0.4379],
+                            [-0.7627,  0.7570, -0.9872],
+                            [ 0.7603,  0.7568, -0.9883],
+                            [-1.1313, -0.8928,  2.0267],
+                            [-1.1314, -1.5893,  0.3455],
+                            [ 1.1315, -1.7280,  1.3860],
+                            [ 1.1315,  0.0762,  1.6235],
+                            [-2.3828,  0.5666,  0.4355],
+                            [-0.8972,  1.4009,  1.0747],
+                            [ 2.3828, -0.5672, -0.4356],
+                            [ 0.8980, -1.4027, -1.0759],
+                            [-1.1338,  1.7273, -1.3870],
+                            [-1.1329, -0.0768, -1.6251],
+                            [ 1.1290,  0.8924, -2.0303],
+                            [ 1.1300,  1.5904, -0.3493]])
 cyclohexane_keys = ['cyclohexane', 'c6h12', 'C6H12']
-add_solvent(data, cyclohexane_keys, cyclohexane)
+add_solvent(solvent_data, cyclohexane_keys, cyclohexane)
 
 
 tetrahydrofuran = HydroProperties(density=889,                     # kg/m3
-                               molar_mass=72.11e-3,             # kg/mol
-                               )
+                                  molar_mass=72.11e-3,             # kg/mol
+                                  )
+tetrahydrofuran.Z = np.array(['O']*1 + ['C']*4 + ['H']*8)
+tetrahydrofuran.xyz = np.array([[ 0.000760889, -0.000738525, -1.456851081],
+                                [-0.652804737, -0.977671000, -0.666797608],
+                                [-0.135276924, -0.754196802,  0.753993299],
+                                [ 0.652965710,  0.977170235, -0.666602790],
+                                [ 0.134622392,  0.755233684,  0.754352491],
+                                [-1.737556125, -0.829010551, -0.720475115],
+                                [-0.415216782, -1.967675331, -1.059040344],
+                                [-0.850969390, -1.066076288,  1.514860077],
+                                [ 0.796865925, -1.302852121,  0.910687964],
+                                [ 1.737518733,  0.828788014, -0.720974308],
+                                [ 0.414866234,  1.967002482, -1.058148213],
+                                [ 0.850649795,  1.065510448,  1.514996321],
+                                [-0.796426720,  1.304515754,  0.911888645]])
 tetrahydrofuran_keys = ['thf', 'THF', 'Tetrahydrofuran', 'tetrahydrofuran']
-add_solvent(data, tetrahydrofuran_keys, tetrahydrofuran)
+add_solvent(solvent_data, tetrahydrofuran_keys, tetrahydrofuran)
 
 water = HydroProperties(density=1000,                     # kg/m3
-                               molar_mass=18.01528e-3,             # kg/mol
-                               )
+                        molar_mass=18.01528e-3,             # kg/mol
+                        )
+water.Z = np.array(['O'] * 1 + ['H'] * 2)
+water.xyz = np.array([[ 0.000,  0.000,  0.000],
+                      [ 0.928,  0.013,  0.246],
+                      [-0.263, -0.899, -0.21 ]])
 water_keys = ['Water', 'water', 'h2o', 'H2O']
-add_solvent(data, water_keys, water)
+add_solvent(solvent_data, water_keys, water)

--- a/pytrx/scatana.py
+++ b/pytrx/scatana.py
@@ -16,7 +16,7 @@ from pytrx import scatsim, hydro
 #   - the goal for Solute is to generate a function that computes Debye difference as a function of some parameters, where number of parameters goes from 0 (None) to whatever
 #   - it should be able to accept filepath (str), Molecule instance, VibratingMolecule (may be)
 #   - Solute output (or method, attribute, it should return) -  f(q, parameters), this f is the difference signal S_es(q,some_parameters) - S_gs(q, some_other_parameters), parameters should be ablot to be 0 or None
-#   - * write Cage class - accept dense girdded q, ds, and covariance (emphasize in Q space) OR accept diff_gr (TBD)
+#   - * write Cage class - accept dense gridded q, ds, and covariance (emphasize in Q space) OR accept diff_gr (TBD)
 #   - * write Solvent Class - TBD
 #   - * write fitting routines (regressors) - WLS, GLS, and TLS
 #   - More thoughts on Solute class:

--- a/pytrx/scatdata.py
+++ b/pytrx/scatdata.py
@@ -1102,14 +1102,14 @@ def plotOutliers(q, x, delay_str, t_str, isOutlier, chisq,
         x_loc = x[:, sel_loc]
         isOutlier_loc = isOutlier[sel_loc]
         x_av_loc = np.mean(x_loc[:, ~isOutlier_loc], axis=1)
-        plt.plot(q, x_loc[:, ~isOutlier_loc] - y_offset_i, 'k-', alpha=0.33)
+        plt.plot(q, x_loc[:, ~isOutlier_loc] - y_offset_i, 'k-', alpha=0.33, zorder=5)
         if x_loc[:, isOutlier_loc].size > 0:
-            plt.plot(q, x_loc[:, isOutlier_loc] - y_offset_i, 'b-')
-        plt.plot(q, x_av_loc - y_offset_i, 'r-')
+            plt.plot(q, x_loc[:, isOutlier_loc] - y_offset_i, 'b-', zorder=10)
+        plt.plot(q, x_av_loc - y_offset_i, 'r-', zorder=20)
         # print(np.sum(~isOutlier_loc), isOutlier_loc)
         msg = f'{each_t}\n{np.sum(~isOutlier_loc)}/{len(isOutlier_loc)}'
         plt.text(q.min() + (q.max() - q.min()) * 0.75, y_offset * 0.25 - y_offset_i, msg, va='center', ha='center',
-                 backgroundcolor='w')
+                 backgroundcolor='w', zorder=3)
 
     plt.hlines(-np.arange(chisqThresh.size) * y_offset, q.min(), q.max())
     plt.legend(custom_lines, ['Data', 'Outliers', 'Mean'])

--- a/pytrx/scatsim.py
+++ b/pytrx/scatsim.py
@@ -16,109 +16,94 @@ import pkg_resources
 from pytrx import hydro
 
 
-
 class Molecule:
     def __init__(self, Z, xyz,
                  calc_gr=False, rmin=0, rmax=25, dr=0.01):
         if type(Z) == str:
             Z = np.array([Z])
         self.Z = Z
-        self.Z_num =np.array([z_str2num(z) for z in Z])
-        
+        self.Z_num = np.array([z_str2num(z) for z in Z])
+
         self.xyz = xyz
-        
+
         if calc_gr: self.calcGR(rmin=rmin, rmax=rmax, dr=dr)
-            
-        
+
     def calcDistMat(self):
         self.dist_mat = np.sqrt(np.sum((self.xyz[None, :, :] -
-                                        self.xyz[:, None, :])**2, axis=2))
-        
-        
+                                        self.xyz[:, None, :]) ** 2, axis=2))
+
     def calcGR(self, rmin=0, rmax=25, dr=0.01):
         self.calcDistMat()
         self.gr = GR(self.Z, rmin=rmin, rmax=rmax, dr=dr)
         self.r = self.gr.r
         for pair in self.gr.el_pairs:
             el1, el2 = pair
-            idx1, idx2 = (el1==self.Z, el2==self.Z)
+            idx1, idx2 = (el1 == self.Z, el2 == self.Z)
             self.gr[pair] += np.histogram(self.dist_mat[np.ix_(idx1, idx2)].ravel(),
                                           self.gr.r_bins)[0]
-            
+
     def calcDens(self):
         self.gr.calcDens()
         self.dens = self.gr.dens
-        
-   
+
 
 class GR:
     def __init__(self, Z, rmin=0, rmax=25, dr=0.01, r=None, el_pairs=None):
-        
+
         self.Z = np.unique(Z)
         if el_pairs is None:
             self.el_pairs = [(z_i, z_j) for i, z_i in enumerate(self.Z) for z_j in self.Z[i:]]
         else:
             self.el_pairs = el_pairs
-        
+
         if r is None:
-#            self.r = np.arange(rmin, rmax+dr, dr)
-            self.r = np.linspace(rmin, rmax, int((rmax - rmin)/dr) + 1)
+            #            self.r = np.arange(rmin, rmax+dr, dr)
+            self.r = np.linspace(rmin, rmax, int((rmax - rmin) / dr) + 1)
         else:
             self.r = r
-            rmin, rmax, dr = r.min(), r.max(), r[1]-r[0]
-#        self.r_bins = np.arange(rmin-0.5*dr, rmax+1.5*dr, dr)
-        self.r_bins = np.linspace(rmin-0.5*dr, rmax+0.5*dr, (rmax - rmin)/dr + 2)
-        
+            rmin, rmax, dr = r.min(), r.max(), r[1] - r[0]
+        #        self.r_bins = np.arange(rmin-0.5*dr, rmax+1.5*dr, dr)
+        self.r_bins = np.linspace(rmin - 0.5 * dr, rmax + 0.5 * dr, (rmax - rmin) / dr + 2)
+
         self.gr = {}
         for pair in self.el_pairs:
             self.gr[frozenset(pair)] = np.zeros(self.r.size)
-        
-        
+
     def __setitem__(self, key, data):
         key = frozenset(key)
         self.gr[key] = data
-    
-    
+
     def __getitem__(self, key):
         key = frozenset(key)
         return self.gr[key]
-    
-    
+
     def __add__(self, gr_other):
         gr_out = GR(self.Z, r=self.r, el_pairs=self.el_pairs)
         for pair in self.el_pairs:
             gr_out[pair] = self[pair] + gr_other[pair]
         return gr_out
-    
-    
+
     def __sub__(self, gr_other):
         gr_out = GR(self.Z, r=self.r, el_pairs=self.el_pairs)
         for pair in self.el_pairs:
             gr_out[pair] = self[pair] - gr_other[pair]
         return gr_out
-    
 
     def __mul__(self, factor):
         gr_out = GR(self.Z, r=self.r, el_pairs=self.el_pairs)
         for pair in self.el_pairs:
             gr_out[pair] = self[pair] * factor
         return gr_out
-    
-    
+
     def calcDens(self):
         self.dens = np.zeros(self.r.shape)
         for pair in self.el_pairs:
             el1, el2 = pair
             z1 = z_str2num(el1)
             z2 = z_str2num(el2)
-            self.dens += z1*z2*self.gr[frozenset(pair)]
+            self.dens += z1 * z2 * self.gr[frozenset(pair)]
 
 
-
-    
-        
-        
-        
 ### UTILS
 
 
@@ -128,37 +113,37 @@ def formFactor(q, Elements):
     q - np.array of scattering vector values
     Elements - np.array or list of elements. May be a string if one wants to
     compute form-factor for only one element.
-    
+
     returns a dict of form factors
-    
+
     Examples:
-    
-    q = np.arange(10)    
+
+    q = np.arange(10)
     f = formFactor(q, 'Si')
     print(f['Si'])
-    
+
     Elements = ['Si', 'O']
     f = formFactor(q, Elements)
     print(f['Si'], f['O'])
     '''
-    
-    Elements = np.unique(Elements)    
-    
+
+    Elements = np.unique(Elements)
+
     fname = pkg_resources.resource_filename('pytrx', './f0_WaasKirf.dat')
     with open(fname) as f:
         content = f.readlines()
-    
-    s = q/(4*pi)
-    formFunc = lambda sval, a: np.sum(a[None, :5]*np.exp(-a[None, 6:]*sval[:, None]**2), axis=1) + a[5]
-    
+
+    s = q / (4 * pi)
+    formFunc = lambda sval, a: np.sum(a[None, :5] * np.exp(-a[None, 6:] * sval[:, None] ** 2), axis=1) + a[5]
+
     f = {}
-    for i,x in enumerate(content):
-        if x[0:2]=='#S':
+    for i, x in enumerate(content):
+        if x[0:2] == '#S':
             atom = x.split()[-1]
-            if any([atom==x for x in Elements]):
-                coef = np.fromstring(content[i+3], sep='\t')
+            if any([atom == x for x in Elements]):
+                coef = np.fromstring(content[i + 3], sep='\t')
                 f[atom] = formFunc(s, coef)
-    
+
     return f
 
 
@@ -167,86 +152,83 @@ def Debye(q, mol, f=None, atomOnly=False):
         f = formFactor(q, mol.Z)
     Scoh = np.zeros(q.shape)
     mol.calcDistMat()
-#    for el1 in f.keys():
-#        idx1 = el1 == mol.Z
-#        
-#        for el2 in f.keys():
-#            idx2 = el2 == mol.Z
-#            r12 = mol.dist_mat[np.ix_(idx1, idx2)].ravel()
-#            qr12 = q[:, None]*r12[None, :]
-#            qr12[qr12<1e-6] = 1e-6 # to deal with r an q == 0
-#            Scoh += f[el1]*f[el2]*np.sum(np.sin(qr12)/qr12, axis=1)
+    #    for el1 in f.keys():
+    #        idx1 = el1 == mol.Z
+    #
+    #        for el2 in f.keys():
+    #            idx2 = el2 == mol.Z
+    #            r12 = mol.dist_mat[np.ix_(idx1, idx2)].ravel()
+    #            qr12 = q[:, None]*r12[None, :]
+    #            qr12[qr12<1e-6] = 1e-6 # to deal with r an q == 0
+    #            Scoh += f[el1]*f[el2]*np.sum(np.sin(qr12)/qr12, axis=1)
     natoms = mol.Z.size
     for idx1 in range(natoms):
         if not atomOnly:
-            for idx2 in range(idx1+1, natoms):
+            for idx2 in range(idx1 + 1, natoms):
                 r12 = mol.dist_mat[idx1, idx2]
-                qr12 = q*r12
-                Scoh += 2 * f[mol.Z[idx1]] * f[mol.Z[idx2]] * np.sin(qr12)/qr12
-        Scoh += f[mol.Z[idx1]]**2
-    
+                qr12 = q * r12
+                Scoh += 2 * f[mol.Z[idx1]] * f[mol.Z[idx2]] * np.sin(qr12) / qr12
+        Scoh += f[mol.Z[idx1]] ** 2
+
     return Scoh
-        
 
 
 def DebyeFromGR(q, gr, f=None, rmax=None, cage=False):
     if f is None:
         f = formFactor(q, gr.Z)
     if rmax is None: rmax = gr.r.max()
-    
+
     Scoh = np.zeros(q.shape)
-    rsel = gr.r<rmax
-    qr = q[:, None]*gr.r[None, rsel]
-    qr[qr<1e-6] = 1e-6
-    Asin = np.sin(qr)/qr
-    
+    rsel = gr.r < rmax
+    qr = q[:, None] * gr.r[None, rsel]
+    qr[qr < 1e-6] = 1e-6
+    Asin = np.sin(qr) / qr
+
     for pair in gr.el_pairs:
         el1, el2 = pair
-#        print(Asin.shape, gr[pair].shape)
+        #        print(Asin.shape, gr[pair].shape)
         pair_scat = f[el1] * f[el2] * (Asin @ gr[pair][rsel])
-        if el1==el2:
+        if el1 == el2:
             if cage:
-                Scoh += 2*pair_scat
+                Scoh += 2 * pair_scat
             else:
                 Scoh += pair_scat
         else:
-            Scoh += 2*pair_scat
-        
-    
+            Scoh += 2 * pair_scat
+
     return Scoh
 
 
 def ScatFromDens(q, gr):
     gr.calcDens()
-    qr = q[:, None]*gr.r[None, :]
-    qr[qr<1e-6] = 1e-6
-    Asin = np.sin(qr)/qr
+    qr = q[:, None] * gr.r[None, :]
+    qr[qr < 1e-6] = 1e-6
+    Asin = np.sin(qr) / qr
     return Asin @ gr.dens
-    
-    
+
 
 def Compton(z, q):
     fname_lowz = pkg_resources.resource_filename('pytrx', './Compton_lowZ.dat')
     fname_highz = pkg_resources.resource_filename('pytrx', './Compton_highZ.dat')
-    
+
     data_lowz = pd.read_csv(fname_lowz, sep='\t')
     data_highz = pd.read_csv(fname_highz, sep='\t')
     data_lowz['Z'] = data_lowz['Z'].apply(lambda x: z_num2str(x))
     data_highz['Z'] = data_highz['Z'].apply(lambda x: z_num2str(x))
-    
-    Scoh = formFactor(q, z)[z]**2
+
+    Scoh = formFactor(q, z)[z] ** 2
     z_num = z_str2num(z)
-    
+
     if z in data_lowz['Z'].values:
-        M, K, L = data_lowz[data_lowz['Z']==z].values[0,1:4]
-        S_inc = (z_num - Scoh/z_num) * (1-M*(np.exp(-K*q/(4*pi))-np.exp(-L*q/(4*pi))))
-#        S(idx_un(i),:) = (Z_un(i)-Scoh(idx_un(i),:)/Z_un(i)).*...
-#                         (1-M*(exp(-K*Q/(4*pi))-exp(-L*Q/(4*pi))));
+        M, K, L = data_lowz[data_lowz['Z'] == z].values[0, 1:4]
+        S_inc = (z_num - Scoh / z_num) * (1 - M * (np.exp(-K * q / (4 * pi)) - np.exp(-L * q / (4 * pi))))
+    #        S(idx_un(i),:) = (Z_un(i)-Scoh(idx_un(i),:)/Z_un(i)).*...
+    #                         (1-M*(exp(-K*Q/(4*pi))-exp(-L*Q/(4*pi))));
     elif z in data_highz['Z'].values:
-        A, B, C = data_highz[data_highz['Z']==z].values[0,1:4]
-        S_inc = z_num*(1 - A/(1+B*q/(4*pi))**C)
-#        S(idx_un(i),:) = Z_un(i)*(1-A./(1+B*Q/(4*pi)).^C);
-    
+        A, B, C = data_highz[data_highz['Z'] == z].values[0, 1:4]
+        S_inc = z_num * (1 - A / (1 + B * q / (4 * pi)) ** C)
+    #        S(idx_un(i),:) = Z_un(i)*(1-A./(1+B*Q/(4*pi)).^C);
+
     elif z == 'H':
         S_inc = np.zeros(q.shape)
     else:
@@ -261,8 +243,8 @@ def fromXYZ(filename, n_header=0):
     with open(filename) as f:
         for line in f.readlines():
             values = line.split()
-            if (line[0] != '#') and (len(values)==4):
-                try: 
+            if (line[0] != '#') and (len(values) == 4):
+                try:
                     z = z_num2str(int(values[0]))
                 except ValueError:
                     z = values[0]
@@ -271,8 +253,8 @@ def fromXYZ(filename, n_header=0):
     xyz = np.array(xyz)
     Z = np.array(Z)
     return Molecule(Z, xyz)
-            
-    
+
+
 def FiletoZXYZ(filepath):
     ZXYZ = pd.read_csv(filepath, names=['Z', 'x', 'y', 'z'], sep='\s+')
     return ZXYZ
@@ -280,75 +262,70 @@ def FiletoZXYZ(filepath):
 
 def totalScattering(q, mol, atomOnly=False):
     s_debye = Debye(q, mol, atomOnly=atomOnly)
-    
+
     s_inc = np.zeros(q.shape)
     for z in mol.Z:
         s_inc += Compton(z, q)
-    
+
     return s_debye + s_inc
 
 
-
 def Solvent(name_str):
-    if name_str in hydro.acetonitrile_keys:
-       Z = np.array(['C', 'C', 'H', 'H', 'H', 'N'])
-       xyz = np.array([[  0.000000,    0.000000,    0.006313],
-                       [  0.000000,    0.000000,    1.462539],
-                       [  1.024583,    0.000000,   -0.370908],
-                       [ -0.512291,   -0.887315,   -0.370908],
-                       [ -0.512291,    0.887315,   -0.370908],
-                       [  0.000000,    0.000000,    2.615205]])
-    elif name_str in hydro.cyclohexane_keys:
-        Z = np.array(['C']*6 + ['H']*12)
-        xyz = np.array([[-0.7613, -0.7573,  0.9857],               
-                        [ 0.7614, -0.7575,  0.9855],               
-                        [-1.2697,  0.5686,  0.4362],               
-                        [ 1.2693, -0.5690, -0.4379],               
-                        [-0.7627,  0.7570, -0.9872],               
-                        [ 0.7603,  0.7568, -0.9883],               
-                        [-1.1313, -0.8928,  2.0267],               
-                        [-1.1314, -1.5893,  0.3455],               
-                        [ 1.1315, -1.7280,  1.3860],               
-                        [ 1.1315,  0.0762,  1.6235],               
-                        [-2.3828,  0.5666,  0.4355],               
-                        [-0.8972,  1.4009,  1.0747],               
-                        [ 2.3828, -0.5672, -0.4356],               
-                        [ 0.8980, -1.4027, -1.0759],               
-                        [-1.1338,  1.7273, -1.3870],               
-                        [-1.1329, -0.0768, -1.6251],               
-                        [ 1.1290,  0.8924, -2.0303],               
-                        [ 1.1300,  1.5904, -0.3493]])
-    elif name_str in hydro.tetrahydrofuran_keys:
-        # structure is taken from SI of Cryst. Growth Des., 2015, 15 (3), pp 1073–1081 DOI: 10.1021/cg501228w
-        Z = np.array(['O']*1 + ['C']*4 + ['H']*8)
-        xyz = np.array([[ 0.000760889, -0.000738525, -1.456851081],
-                        [-0.652804737, -0.977671000, -0.666797608],
-                        [-0.135276924, -0.754196802,  0.753993299],
-                        [ 0.652965710,  0.977170235, -0.666602790],
-                        [ 0.134622392,  0.755233684,  0.754352491],
-                        [-1.737556125, -0.829010551, -0.720475115],
-                        [-0.415216782, -1.967675331, -1.059040344],
-                        [-0.850969390, -1.066076288,  1.514860077],
-                        [ 0.796865925, -1.302852121,  0.910687964],
-                        [ 1.737518733,  0.828788014, -0.720974308],
-                        [ 0.414866234,  1.967002482, -1.058148213],
-                        [ 0.850649795,  1.065510448,  1.514996321],
-                        [-0.796426720,  1.304515754,  0.911888645]])
-    elif name_str in hydro.water_keys:
-        Z = np.array(['O'] * 1 + ['H'] * 2)
-        xyz = np.array([[ 0.   ,  0.   ,  0.   ],
-                        [ 0.928,  0.013,  0.246],
-                        [-0.263, -0.899, -0.21 ]])
-    else:
-        return None
-    return Molecule(Z, xyz)
-        
-        
+    # if name_str in hydro.acetonitrile_keys:
+    #    Z = np.array(['C', 'C', 'H', 'H', 'H', 'N'])
+    #    xyz = np.array([[  0.000000,    0.000000,    0.006313],
+    #                    [  0.000000,    0.000000,    1.462539],
+    #                    [  1.024583,    0.000000,   -0.370908],
+    #                    [ -0.512291,   -0.887315,   -0.370908],
+    #                    [ -0.512291,    0.887315,   -0.370908],
+    #                    [  0.000000,    0.000000,    2.615205]])
+    # elif name_str in hydro.cyclohexane_keys:
+    #     Z = np.array(['C']*6 + ['H']*12)
+    #     xyz = np.array([[-0.7613, -0.7573,  0.9857],
+    #                     [ 0.7614, -0.7575,  0.9855],
+    #                     [-1.2697,  0.5686,  0.4362],
+    #                     [ 1.2693, -0.5690, -0.4379],
+    #                     [-0.7627,  0.7570, -0.9872],
+    #                     [ 0.7603,  0.7568, -0.9883],
+    #                     [-1.1313, -0.8928,  2.0267],
+    #                     [-1.1314, -1.5893,  0.3455],
+    #                     [ 1.1315, -1.7280,  1.3860],
+    #                     [ 1.1315,  0.0762,  1.6235],
+    #                     [-2.3828,  0.5666,  0.4355],
+    #                     [-0.8972,  1.4009,  1.0747],
+    #                     [ 2.3828, -0.5672, -0.4356],
+    #                     [ 0.8980, -1.4027, -1.0759],
+    #                     [-1.1338,  1.7273, -1.3870],
+    #                     [-1.1329, -0.0768, -1.6251],
+    #                     [ 1.1290,  0.8924, -2.0303],
+    #                     [ 1.1300,  1.5904, -0.3493]])
+    # elif name_str in hydro.tetrahydrofuran_keys:
+    #     # structure is taken from SI of Cryst. Growth Des., 2015, 15 (3), pp 1073–1081 DOI: 10.1021/cg501228w
+    #     Z = np.array(['O']*1 + ['C']*4 + ['H']*8)
+    #     xyz = np.array([[ 0.000760889, -0.000738525, -1.456851081],
+    #                     [-0.652804737, -0.977671000, -0.666797608],
+    #                     [-0.135276924, -0.754196802,  0.753993299],
+    #                     [ 0.652965710,  0.977170235, -0.666602790],
+    #                     [ 0.134622392,  0.755233684,  0.754352491],
+    #                     [-1.737556125, -0.829010551, -0.720475115],
+    #                     [-0.415216782, -1.967675331, -1.059040344],
+    #                     [-0.850969390, -1.066076288,  1.514860077],
+    #                     [ 0.796865925, -1.302852121,  0.910687964],
+    #                     [ 1.737518733,  0.828788014, -0.720974308],
+    #                     [ 0.414866234,  1.967002482, -1.058148213],
+    #                     [ 0.850649795,  1.065510448,  1.514996321],
+    #                     [-0.796426720,  1.304515754,  0.911888645]])
+    # elif name_str in hydro.water_keys:
+    #     Z = np.array(['O'] * 1 + ['H'] * 2)
+    #     xyz = np.array([[ 0.   ,  0.   ,  0.   ],
+    #                     [ 0.928,  0.013,  0.246],
+    #                     [-0.263, -0.899, -0.21 ]])
+    # else:
+    #     return None
+    # print("Grabbing molecule info")
+    return Molecule(hydro.solvent_data[name_str].Z, hydro.solvent_data[name_str].xyz)
 
-
-
-
-#def convolutedExpDecay(t, tau, tzero, fwhm):
+# def convolutedExpDecay(t, tau, tzero, fwhm):
 #    t = t - tzero
 #    sigma = fwhm/2.355
 #    val = sigma**2 - tau*t
@@ -357,13 +334,11 @@ def Solvent(name_str):
 #
 #
 #
-#def convolutedStep(t, tzero, fwhm):
+# def convolutedStep(t, tzero, fwhm):
 #    t = t - tzero
 #    sigma = fwhm/2.355
 #    val = t / (np.sqrt(2)*sigma)
 #    return (1/2 * (1 + erf(val)))
-
-
 
 
 # if __name__ == '__main__':
@@ -424,5 +399,4 @@ def Solvent(name_str):
 #     plt.plot(q, (Debye(q, mol2) - Debye(q, mol1)), '.-')
 #     plt.plot(q, 1/n_mol*(DebyeFromGR(q, ens2.gr) - DebyeFromGR(q, ens1.gr)))
 #
-    
-    
+

--- a/pytrx/utils.py
+++ b/pytrx/utils.py
@@ -132,4 +132,6 @@ def ElementString():
     ElementString = 'H He Li Be B C N O F Ne Na Mg Al Si P S Cl Ar K Ca Sc Ti V Cr Mn Fe Co Ni Cu Zn Ga Ge As Se Br Kr Rb Sr Y Zr Nb Mo Tc Ru Rh Pd Ag Cd In Sn Sb Te I Xe Cs Ba La Ce Pr Nd Pm Sm Eu Gd Tb Dy Ho Er Tm Yb Lu Hf Ta W Re Os Ir Pt Au Hg Tl Pb Bi Po At Rn Fr Ra Ac Th Pa U Np Pu Am Cm Bk Cf Es Fm Md No Lr Rf Db Sg Bh Hs Mt Ds Rg Cn Nh Fl Mc Lv Ts Og'
     return ElementString.split()
 
-
+def AtomicMass():
+    AtomicMass = np.array([1.00797, 4.0026, 6.941, 9.01218, 10.81, 12.011, 14.0067, 15.9994, 18.998403, 20.179, 22.98977, 24.305, 26.98154, 28.0855, 30.97376, 32.06, 35.453, 39.0983, 39.948, 40.08, 44.9559, 47.9, 50.9415, 51.996, 54.938, 55.847, 58.7, 58.9332, 63.546, 65.38, 69.72, 72.59, 74.9216, 78.96, 79.904, 83.8, 85.4678, 87.62, 88.9059, 91.22, 92.9064, 95.94, -98, 101.07, 102.9055, 106.4, 107.868, 112.41, 114.82, 118.69, 121.75, 126.9045, 127.6, 131.3, 132.9054, 137.33, 138.9055, 140.12, 140.9077, 144.24, -145, 150.4, 151.96, 157.25, 158.9254, 162.5, 164.9304, 167.26, 168.9342, 173.04, 174.967, 178.49, 180.9479, 183.85, 186.207, 190.2, 192.22, 195.09, 196.9665, 200.59, 204.37, 207.2, 208.9804, 209, 210, 222, 223, 226.0254, 227.0278, 231.0359, 232.0381, 237.0482, 238.029])
+    return AtomicMass


### PR DESCRIPTION
1. scatdata.py was reformatted by pycharm hence so many edits
2. the solvent information has been moved from scatsim.py to hydro.py
3. added transform function for solute, where users supply a list of step, each step being a defined list (see docstring) that moves some groups of the atoms in the system (can be defined manually). The function call to calculate signal is the same.
The transform is operating on the mol_es field. Before each transform, mol_es is copied from (reset by) mol_es_ref that is exactly the loaded structure for reproducibility.

More modes of moving atoms should be added in the future